### PR TITLE
fix: resolve TypeScript errors on amazon alexa page

### DIFF
--- a/frontend/src/app/portfolio/caseStudies/AmazonAlexa/components/hero.tsx
+++ b/frontend/src/app/portfolio/caseStudies/AmazonAlexa/components/hero.tsx
@@ -13,7 +13,7 @@ export default function AmazonAlexaHero() {
       transition: { 
         duration: 0.8, 
         delay: custom * 0.15, 
-        ease: [0.21, 0.47, 0.32, 0.98] 
+        ease: [0.21, 0.47, 0.32, 0.98] as const
       }
     })
   };


### PR DESCRIPTION
The ease array in the fadeInUp variants needed to be typed as a constant tuple for Framer Motion

## Description
 The ease array in the fadeInUp variants needed to be typed as a constant tuple for Framer Motion. Added "as const" to the end of the array.

## Related Issue
n/a


## Motivation and Context
resolve 5 TypeScript errors in file

## How Has This Been Tested?
npm run dev

## Checklist before requesting a review
- [X ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.

## Screenshots (if appropriate):
