### PR TITLE
feat: add case studies and companies to admin page

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1329,7 +1329,6 @@
       "integrity": "sha512-6mDvHUFSjyT2B2yeNx2nUgMxh9LtOWvkhIU3uePn2I2oyNymUAX1NIsdgviM4CH+JSrp2D2hsMvJOkxY+0wNRA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -1390,7 +1389,6 @@
       "integrity": "sha512-n1H6IcDhmmUEG7TNVSspGmiHHutt7iVKtZwRppD7e04wha5MrkV1h3pti9xQLcCMt6YWsncpoT0HMjkH1FNwWQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.46.0",
         "@typescript-eslint/types": "8.46.0",
@@ -1908,7 +1906,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2768,7 +2765,6 @@
       "integrity": "sha512-XyLmROnACWqSxiGYArdef1fItQd47weqB7iwtfr9JHwRrqIXZdcFMvvEcL9xHCmL0SNsOvF0c42lWyM1U5dgig==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -2943,7 +2939,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -5234,7 +5229,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
       "integrity": "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5244,7 +5238,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.0.tgz",
       "integrity": "sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.26.0"
       },
@@ -5938,7 +5931,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6088,7 +6080,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/frontend/src/app/admin/page.tsx
+++ b/frontend/src/app/admin/page.tsx
@@ -10,20 +10,29 @@ export default function AdminPage() {
   const router = useRouter();
   const [isWhitelisted, setIsWhitelisted] = useState(false);
   const [isLoadingWhitelist, setIsLoadingWhitelist] = useState(true);
+  const [data, setData] = useState<any[]>([]);
+  const [isLoadingData, setIsLoadingData] = useState(false);
+
+  const fetchData = async () => {
+    setIsLoadingData(true);
+    try {
+      const response = await fetch("http://localhost:8080/api/overview");
+      const overviewData = await response.json();
+      setData(overviewData);
+    } catch (error) {
+      console.error("Error fetching overview data:", error);
+    } finally {
+      setIsLoadingData(false);
+    }
+  };
 
   useEffect(() => {
     if (status === "unauthenticated") {
       router.push("/login");
     } else if (status === "authenticated" && session?.user?.email) {
-      // In a real application, you would call your backend here to check if the user is whitelisted
-      // For now, we'll simulate a check
       const checkWhitelist = async () => {
         setIsLoadingWhitelist(true);
-
-        if (status !== "authenticated" || !session?.user?.email) return;
-        
         try {
-          // Replace with your actual backend call
           const response = await fetch(
             "http://localhost:8080/api/check-whitelist",
             {
@@ -35,16 +44,14 @@ export default function AdminPage() {
             },
           );
           const data = await response.json();
-          console.log(session);
           if (data.isWhitelisted) {
             setIsWhitelisted(true);
           } else {
-            // Not whitelisted, redirect to an unauthorized page or home
-            router.push("/"); // Redirect to home or a specific unauthorized page
+            router.push("/");
           }
         } catch (error) {
           console.error("Error checking whitelist:", error);
-          router.push("/"); // Redirect on error
+          router.push("/");
         } finally {
           setIsLoadingWhitelist(false);
         }
@@ -53,43 +60,220 @@ export default function AdminPage() {
     }
   }, [session, status, router]);
 
+  useEffect(() => {
+    if (isWhitelisted) {
+      fetchData();
+    }
+  }, [isWhitelisted]);
+
+  const handleDeleteCompany = async (companyID: string) => {
+    if (!confirm(`Are you sure you want to delete company ${companyID}?`))
+      return;
+
+    try {
+      const response = await fetch(
+        `http://localhost:8080/api/company/${companyID}`,
+        {
+          method: "DELETE",
+        },
+      );
+      if (response.ok) {
+        fetchData();
+      } else {
+        alert("Failed to delete company");
+      }
+    } catch (error) {
+      console.error("Error deleting company:", error);
+    }
+  };
+
+  const handleDeleteCaseStudy = async (
+    companyID: string,
+    templateID: string,
+  ) => {
+    if (!confirm(`Are you sure you want to delete case study ${templateID}?`))
+      return;
+
+    try {
+      const response = await fetch(
+        `http://localhost:8080/api/casestudy/${companyID}/${templateID}`,
+        {
+          method: "DELETE",
+        },
+      );
+      if (response.ok) {
+        fetchData();
+      } else {
+        alert("Failed to delete case study");
+      }
+    } catch (error) {
+      console.error("Error deleting case study:", error);
+    }
+  };
+
   if (status === "loading" || isLoadingWhitelist) {
     return (
-      <div className="min-h-screen flex flex-col items-center justify-center text-white">
+      <div className="min-h-screen flex flex-col items-center justify-center text-white bg-background">
         <NavBar />
         <div>
-          <h1 className="text-foreground">Loading...</h1>
+          <h1 className="text-foreground text-2xl">Loading...</h1>
         </div>
       </div>
     );
   }
 
   if (!isWhitelisted) {
-    // This state should ideally be handled by the redirect in useEffect
-    // but as a fallback, we can show a message
     return null;
   }
 
   return (
-    <div className="min-h-screen flex flex-col items-center justify-center text-white">
+    <div className="min-h-screen flex flex-col items-center bg-background text-foreground py-20">
       <NavBar />
-      <div>
-        <h1 className="text-foreground">Welcome to the Admin Page!</h1>
-        <p>You are logged in as: {session?.user?.email}</p>
-        {/* Admin content goes here */}
-        <button
-            onClick={() => signOut({ callbackUrl: "/login" })}
-            className="
-              px-6 py-2
-              bg-red-600
-              hover:bg-red-700
-              transition-colors
-              rounded
-              cursor-pointer
-            "
-          >
-            Logout
-        </button>
+      <div className="w-full max-w-5xl px-6 mt-10">
+        <div className="flex flex-col md:flex-row justify-between items-start md:items-center mb-8 gap-4">
+          <div>
+            <h1 className="text-4xl font-bold">Admin Dashboard</h1>
+            <p className="text-neutral-400 mt-2">
+              Logged in as:{" "}
+              <span className="text-foreground font-semibold">
+                {session?.user?.email}
+              </span>
+            </p>
+          </div>
+          <div className="flex gap-3">
+            <button
+              onClick={() => router.push("/formBuilder")}
+              className="px-4 py-2 bg-blue-600 hover:bg-blue-700 transition-colors rounded text-white font-medium shadow-lg"
+            >
+              + New Case Study
+            </button>
+            <button
+              onClick={() => signOut({ callbackUrl: "/login" })}
+              className="px-4 py-2 bg-neutral-800 hover:bg-neutral-700 transition-colors rounded text-white font-medium border border-neutral-700"
+            >
+              Logout
+            </button>
+          </div>
+        </div>
+
+        <section className="bg-neutral-900/50 rounded-2xl p-8 shadow-2xl border border-neutral-800 backdrop-blur-sm">
+          <div className="flex justify-between items-center mb-8 border-b border-neutral-800 pb-4">
+            <h2 className="text-2xl font-bold">Portfolio Management</h2>
+            <span className="bg-blue-500/10 text-blue-400 px-3 py-1 rounded-full text-sm font-medium border border-blue-500/20">
+              {data.length} Companies Total
+            </span>
+          </div>
+
+          {isLoadingData ? (
+            <div className="flex justify-center py-12">
+              <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-500"></div>
+            </div>
+          ) : data.length === 0 ? (
+            <div className="text-center py-12 bg-neutral-800/20 rounded-xl border border-dashed border-neutral-700">
+              <p className="text-neutral-500">
+                No companies or case studies found in the database.
+              </p>
+            </div>
+          ) : (
+            <div className="space-y-10">
+              {data.map((company: any) => (
+                <div
+                  key={company.CompanyID}
+                  className="bg-neutral-800/30 rounded-xl border border-neutral-700 overflow-hidden transition-all hover:border-neutral-600 shadow-lg"
+                >
+                  <div className="bg-neutral-800/50 p-6 flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4 border-b border-neutral-700">
+                    <div>
+                      <div className="flex items-center gap-3 mb-1">
+                        <h3 className="text-xl font-bold text-white">
+                          {company.Name}
+                        </h3>
+                        <span className="text-[10px] font-mono bg-neutral-700 text-neutral-400 px-2 py-0.5 rounded uppercase tracking-tighter">
+                          {company.CompanyID}
+                        </span>
+                      </div>
+                      <p className="text-sm text-neutral-400 font-medium">
+                        {company.Industry || "Uncategorized"}
+                      </p>
+                    </div>
+                    <button
+                      onClick={() => handleDeleteCompany(company.CompanyID)}
+                      className="text-xs text-red-400 hover:text-red-300 hover:bg-red-400/10 px-3 py-1.5 rounded transition-all border border-red-400/20"
+                    >
+                      Delete Company
+                    </button>
+                  </div>
+
+                  <div className="p-6">
+                    <h4 className="text-xs font-bold text-neutral-500 uppercase tracking-widest mb-4">
+                      Case Studies ({company.CaseStudies?.length || 0})
+                    </h4>
+                    {company.CaseStudies && company.CaseStudies.length > 0 ? (
+                      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                        {company.CaseStudies.map((study: any) => (
+                          <div
+                            key={study.TemplateID}
+                            className="bg-neutral-900/50 p-4 rounded-lg border border-neutral-700/50 flex flex-col justify-between group"
+                          >
+                            <div className="flex justify-between items-start mb-3">
+                              <div>
+                                <span className="text-sm font-bold text-blue-400 block mb-1">
+                                  {study.TemplateID}
+                                </span>
+                                <span className="text-[10px] text-neutral-500 font-medium bg-neutral-800 px-2 py-0.5 rounded">
+                                  {study.Blocks?.length || 0} Content Blocks
+                                </span>
+                              </div>
+                              <button
+                                onClick={() =>
+                                  handleDeleteCaseStudy(
+                                    company.CompanyID,
+                                    study.TemplateID,
+                                  )
+                                }
+                                className="text-neutral-500 hover:text-red-400 transition-colors p-1"
+                                title="Delete Case Study"
+                              >
+                                <svg
+                                  xmlns="http://www.w3.org/2000/svg"
+                                  className="h-4 w-4"
+                                  fill="none"
+                                  viewBox="0 0 24 24"
+                                  stroke="currentColor"
+                                >
+                                  <path
+                                    strokeLinecap="round"
+                                    strokeLinejoin="round"
+                                    strokeWidth={2}
+                                    d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"
+                                  />
+                                </svg>
+                              </button>
+                            </div>
+
+                            <div className="flex gap-2 mt-auto">
+                              <button className="flex-1 text-[10px] font-bold uppercase tracking-wider bg-neutral-800 hover:bg-neutral-700 text-neutral-300 py-2 rounded transition-colors border border-neutral-700">
+                                Edit
+                              </button>
+                              <button className="flex-1 text-[10px] font-bold uppercase tracking-wider bg-blue-600/10 hover:bg-blue-600/20 text-blue-400 py-2 rounded transition-colors border border-blue-500/20">
+                                View
+                              </button>
+                            </div>
+                          </div>
+                        ))}
+                      </div>
+                    ) : (
+                      <div className="text-center py-6 bg-neutral-900/30 rounded-lg border border-neutral-800">
+                        <p className="text-xs text-neutral-600 italic">
+                          No case studies found for this company.
+                        </p>
+                      </div>
+                    )}
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </section>
       </div>
     </div>
   );


### PR DESCRIPTION
## Description
Add case studies, businesses, and admin permissions to the admin page. Some buttons like edit and view don't work, but the delete ones do.

## Related Issue
[Airtable Link](https://airtable.com/appokp66cMjrGGtZX/tblWltzphwnFCt8CL/viwW6LR7YOoTbpEru/recO73dcDZ1MZDfGY?copyLinkToCellOrRecordOrigin=gridView&blocks=hide)

## Motivation and Context
Allows for admins to have more control over and information on what the website is showing

## How Has This Been Tested?
Run locally and tested 

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.

## Screenshots (if appropriate):
<img width="1920" height="1020" alt="image" src="https://github.com/user-attachments/assets/9c133147-a84e-4f70-98a4-1b2ed9034b09" />
<img width="1920" height="1020" alt="image" src="https://github.com/user-attachments/assets/e08d6743-557f-46ba-95bd-ce5dae1125ad" />

