### PR TITLE
style: position updates & animations 

### DIFF
--- a/frontend/src/app/portfolio/caseStudies/Carnival/components/CarnivalFooter.tsx
+++ b/frontend/src/app/portfolio/caseStudies/Carnival/components/CarnivalFooter.tsx
@@ -1,11 +1,20 @@
+"use client";
+
 import Image from "next/image";
+import { motion } from "framer-motion";
 import agencyLogo from "../../CokeZero/assets/AgencyLogoFull.png";
 import carnivalLogo from "../assets/carnival-Logo.svg";
 
 export default function CarnivalFooter() {
   return (
     <div className="flex justify-center px-6 pb-16 pt-8 md:px-12 md:pb-24">
-      <div className="flex flex-col items-center justify-center gap-5 text-white lg:flex-row lg:gap-6">
+      <motion.div
+        initial={{ opacity: 0, y: 30 }}
+        whileInView={{ opacity: 1, y: 0 }}
+        viewport={{ once: true }}
+        transition={{ duration: 0.8, delay: 0.15, ease: [0.21, 0.47, 0.32, 0.98] }}
+        className="flex flex-col items-center justify-center gap-5 text-white lg:flex-row lg:gap-6"
+      >
         <Image
           src={carnivalLogo}
           alt="Carnival"
@@ -19,7 +28,7 @@ export default function CarnivalFooter() {
           alt="The Agency at the University of Florida"
           className="h-auto w-full max-w-[320px] sm:max-w-[420px]"
         />
-      </div>
+      </motion.div>
     </div>
   );
 }

--- a/frontend/src/app/portfolio/caseStudies/Carnival/components/CarnivalHeadlinesSection.tsx
+++ b/frontend/src/app/portfolio/caseStudies/Carnival/components/CarnivalHeadlinesSection.tsx
@@ -13,19 +13,19 @@ import photo3Col2 from "../assets/photo3Col2.png";
 
 export default function CarnivalHeadlinesSection() {
   return (
-    <section className="relative overflow-hidden pb-16 pt-2 md:pb-24">
+    <section className="relative overflow-hidden pb-16 pt-6 md:pt-10 md:pb-24">
       <div className="relative z-10 px-6 md:px-12 lg:px-20">
         <div className="mx-auto max-w-6xl">
-          <div className="relative mt-8 grid gap-5 lg:grid-cols-[minmax(0,1fr)_18rem] xl:grid-cols-[minmax(0,1fr)_20rem]">
+          <div className="relative mt-8 grid gap-5 lg:grid-cols-[minmax(0,1fr)_24rem] xl:grid-cols-[minmax(0,1fr)_26rem]">
             <div className="grid gap-4 md:grid-cols-[1.24fr_0.62fr] lg:h-[26rem] xl:h-[29rem]">
-              <div className="grid h-full gap-4 [grid-template-rows:234fr_384fr]">
+              <div className="grid h-full gap-6 [grid-template-rows:220fr_360fr]">
                 <div className="relative overflow-hidden">
                   <Image
                     src={photo1Col1}
                     alt="CruiseHive article headline"
                     fill
-                    sizes="(min-width: 1280px) 24rem, (min-width: 1024px) 22rem, 100vw"
-                    className="object-cover"
+                    sizes="(min-width: 1280px) 20rem, (min-width: 1024px) 18rem, 100vw"
+                    className="object-contain"
                   />
                 </div>
                 <div className="relative overflow-hidden">
@@ -33,8 +33,8 @@ export default function CarnivalHeadlinesSection() {
                     src={photo2Col1}
                     alt="Carnival newsroom article"
                     fill
-                    sizes="(min-width: 1280px) 24rem, (min-width: 1024px) 22rem, 100vw"
-                    className="object-cover"
+                    sizes="(min-width: 1280px) 20rem, (min-width: 1024px) 18rem, 100vw"
+                    className="object-contain"
                   />
                 </div>
               </div>
@@ -46,7 +46,7 @@ export default function CarnivalHeadlinesSection() {
                     alt="University of Florida article headline"
                     fill
                     sizes="(min-width: 1280px) 12rem, (min-width: 1024px) 11rem, 100vw"
-                    className="object-cover"
+                    className="object-contain"
                   />
                 </div>
                 <div className="relative overflow-hidden">
@@ -55,7 +55,7 @@ export default function CarnivalHeadlinesSection() {
                     alt="Study findings article excerpt"
                     fill
                     sizes="(min-width: 1280px) 12rem, (min-width: 1024px) 11rem, 100vw"
-                    className="object-cover"
+                    className="object-contain"
                   />
                 </div>
                 <div className="relative overflow-hidden">
@@ -64,25 +64,25 @@ export default function CarnivalHeadlinesSection() {
                     alt="Traveler preference article headline"
                     fill
                     sizes="(min-width: 1280px) 12rem, (min-width: 1024px) 11rem, 100vw"
-                    className="object-cover"
+                    className="object-contain"
                   />
                 </div>
               </div>
             </div>
 
-            <div className="relative mx-auto w-full max-w-[18rem] lg:mx-0 lg:h-[26rem] lg:max-w-[18rem] xl:h-[29rem] xl:max-w-[20rem]">
+            <div className="relative mx-auto w-full max-w-[24rem] lg:mx-0 lg:h-[26rem] lg:max-w-[24rem] xl:h-[29rem] xl:max-w-[26rem]">
               <Image
                 src={photo1Col3}
                 alt="Travel enthusiasm infographic"
                 fill
-                sizes="(min-width: 1280px) 20rem, (min-width: 1024px) 18rem, 100vw"
+                sizes="(min-width: 1280px) 26rem, (min-width: 1024px) 24rem, 100vw"
                 className="object-contain"
               />
               
             </div>
           </div>
 
-          <div className="relative mt-14 flex justify-center px-6 pb-2 pt-6 md:mt-18">
+          <div className="relative mt-20 flex justify-center px-6 pb-2 pt-8 md:mt-24">
             <div className="absolute left-0 top-10 h-4 w-4 rounded-full bg-[#D3362D] md:h-5 md:w-5" />
             <div className="absolute -left-10 bottom-2 h-12 w-12 rounded-full bg-[#D3362D] md:h-16 md:w-16" />
             <div className="absolute right-10 top-8 h-4 w-4 rounded-full bg-white md:h-5 md:w-5" />

--- a/frontend/src/app/portfolio/caseStudies/Carnival/components/CarnivalHeadlinesSection.tsx
+++ b/frontend/src/app/portfolio/caseStudies/Carnival/components/CarnivalHeadlinesSection.tsx
@@ -1,7 +1,10 @@
+"use client";
+
+import { useRef } from "react";
 import Image from "next/image";
+import { motion, useInView } from "framer-motion";
 import agencyLogo from "../../CokeZero/assets/AgencyLogoFull.png";
 import carnivalLogo from "../assets/carnival-Logo.svg";
-import dottedRedCircle from "../assets/dotted-redCircle.svg";
 import photo1Col1 from "../assets/photo1Col1.png";
 import photo1Col2 from "../assets/photo1Col2.png";
 import photo1Col3 from "../assets/photo1Col3.png";
@@ -9,16 +12,49 @@ import photo2Col1 from "../assets/photo2Col1.png";
 import photo2Col2 from "../assets/photo2Col2.png";
 import photo3Col2 from "../assets/photo3Col2.png";
 
-
-
 export default function CarnivalHeadlinesSection() {
+  const colsRef = useRef(null);
+  const colsInView = useInView(colsRef, { once: true, amount: 0 });
+
+  const fadeInUp = {
+    hidden: { opacity: 0, y: 30 },
+    visible: {
+      opacity: 1,
+      y: 0,
+      transition: {
+        duration: 0.8,
+        ease: [0.21, 0.47, 0.32, 0.98] as const,
+      },
+    },
+  };
+
+  const staggerContainer = {
+    hidden: {},
+    visible: {
+      transition: {
+        staggerChildren: 0.18,
+        delayChildren: 0.1,
+      },
+    },
+  };
+
   return (
     <section className="relative overflow-hidden pb-16 pt-6 md:pt-10 md:pb-24">
       <div className="relative z-10 px-6 md:px-12 lg:px-20">
         <div className="mx-auto max-w-6xl">
           <div className="relative mt-8 grid gap-5 lg:grid-cols-[minmax(0,1fr)_24rem] xl:grid-cols-[minmax(0,1fr)_26rem]">
-            <div className="grid gap-4 md:grid-cols-[1.24fr_0.62fr] lg:h-[26rem] xl:h-[29rem]">
-              <div className="grid h-full gap-6 [grid-template-rows:220fr_360fr]">
+            {/* Stagger container: col1 then col2 */}
+            <motion.div
+              ref={colsRef}
+              initial="hidden"
+              animate={colsInView ? "visible" : "hidden"}
+              variants={staggerContainer}
+              className="grid gap-4 md:grid-cols-[1.24fr_0.62fr] lg:h-[26rem] xl:h-[29rem]"
+            >
+              <motion.div
+                variants={fadeInUp}
+                className="grid h-full gap-6 [grid-template-rows:220fr_360fr]"
+              >
                 <div className="relative overflow-hidden">
                   <Image
                     src={photo1Col1}
@@ -37,9 +73,12 @@ export default function CarnivalHeadlinesSection() {
                     className="object-contain"
                   />
                 </div>
-              </div>
+              </motion.div>
 
-              <div className="grid h-full gap-5 [grid-template-rows:170fr_213fr_158fr]">
+              <motion.div
+                variants={fadeInUp}
+                className="grid h-full gap-5 [grid-template-rows:170fr_213fr_158fr]"
+              >
                 <div className="relative overflow-hidden">
                   <Image
                     src={photo1Col2}
@@ -67,10 +106,17 @@ export default function CarnivalHeadlinesSection() {
                     className="object-contain"
                   />
                 </div>
-              </div>
-            </div>
+              </motion.div>
+            </motion.div>
 
-            <div className="relative mx-auto w-full max-w-[24rem] lg:mx-0 lg:h-[26rem] lg:max-w-[24rem] xl:h-[29rem] xl:max-w-[26rem]">
+            {/* col3 — delayed to follow after col1+col2 */}
+            <motion.div
+              initial={{ opacity: 0, y: 30 }}
+              whileInView={{ opacity: 1, y: 0 }}
+              viewport={{ once: true }}
+              transition={{ duration: 0.8, delay: 0.46, ease: [0.21, 0.47, 0.32, 0.98] }}
+              className="relative mx-auto w-full max-w-[24rem] lg:mx-0 lg:h-[26rem] lg:max-w-[24rem] xl:h-[29rem] xl:max-w-[26rem]"
+            >
               <Image
                 src={photo1Col3}
                 alt="Travel enthusiasm infographic"
@@ -78,8 +124,7 @@ export default function CarnivalHeadlinesSection() {
                 sizes="(min-width: 1280px) 26rem, (min-width: 1024px) 24rem, 100vw"
                 className="object-contain"
               />
-              
-            </div>
+            </motion.div>
           </div>
 
           <div className="relative mt-20 flex justify-center px-6 pb-2 pt-8 md:mt-24">
@@ -87,9 +132,15 @@ export default function CarnivalHeadlinesSection() {
             <div className="absolute -left-10 bottom-2 h-12 w-12 rounded-full bg-[#D3362D] md:h-16 md:w-16" />
             <div className="absolute right-10 top-8 h-4 w-4 rounded-full bg-white md:h-5 md:w-5" />
             <div className="absolute right-0 bottom-1 h-16 w-16 rounded-full bg-white md:h-20 md:w-20" />
-          
 
-            <div className="relative z-10 flex flex-col items-center justify-center gap-5 text-white lg:flex-row lg:gap-6">
+            <motion.div
+              custom={1}
+              initial="hidden"
+              whileInView="visible"
+              viewport={{ once: true }}
+              variants={fadeInUp}
+              className="relative z-10 flex flex-col items-center justify-center gap-5 text-white lg:flex-row lg:gap-6"
+            >
               <Image
                 src={carnivalLogo}
                 alt="Carnival"
@@ -103,7 +154,7 @@ export default function CarnivalHeadlinesSection() {
                 alt="The Agency at the University of Florida"
                 className="h-auto w-full max-w-[280px] sm:max-w-[380px]"
               />
-            </div>
+            </motion.div>
           </div>
         </div>
       </div>

--- a/frontend/src/app/portfolio/caseStudies/Carnival/components/CarnivalLandingSection.tsx
+++ b/frontend/src/app/portfolio/caseStudies/Carnival/components/CarnivalLandingSection.tsx
@@ -1,4 +1,5 @@
 import Image from "next/image";
+import { gentonaBold } from "@/app/fonts";
 import agencyLogo from "../../CokeZero/assets/AgencyLogoFull.png";
 import carnivalLogo from "../assets/carnival-Logo.svg";
 
@@ -33,7 +34,9 @@ export default function CarnivalLandingSection() {
 
         <div className="mt-6 h-[4px] w-full max-w-[48rem] bg-[#EF3340] sm:max-w-[28rem] lg:max-w-[56rem]" />
 
-        <h2 className="mt-30 max-w-4xl text-3xl font-bold leading-tight sm:text-4xl lg:text-5xl">
+        <h2
+          className={`${gentonaBold.className} mt-30 max-w-4xl text-3xl font-bold leading-tight sm:text-4xl lg:text-5xl`}
+        >
           The Agency Helps Carnival Navigate the Sentiments of Travelers Post-2021
         </h2>
       </div>

--- a/frontend/src/app/portfolio/caseStudies/Carnival/components/CarnivalLandingSection.tsx
+++ b/frontend/src/app/portfolio/caseStudies/Carnival/components/CarnivalLandingSection.tsx
@@ -1,20 +1,48 @@
+"use client";
+
 import Image from "next/image";
 import { gentonaBold } from "@/app/fonts";
 import agencyLogo from "../../CokeZero/assets/AgencyLogoFull.png";
 import carnivalLogo from "../assets/carnival-Logo.svg";
+import { motion } from "framer-motion";
 
 export default function CarnivalLandingSection() {
+  const fadeInUp = {
+    hidden: { opacity: 0, y: 30 },
+    visible: (custom: number) => ({
+      opacity: 1,
+      y: 0,
+      transition: {
+        duration: 0.8,
+        delay: custom * 0.15,
+        ease: [0.21, 0.47, 0.32, 0.98] as const,
+      },
+    }),
+  };
+
   return (
     <section
       id="carnival-landing"
       className="relative flex min-h-screen items-center overflow-hidden"
     >
       <div className="relative z-10 w-full max-w-6xl px-6 pt-28 pb-12 text-white sm:px-10 md:px-14 lg:px-20">
-        <p className="mb-5 inline-flex h-[50px] w-[160px] items-center justify-center border-4 border-[#EF3340] bg-[#0d1c46]/50 text-xl font-bold text-white">
+        <motion.p
+          custom={1}
+          initial="hidden"
+          animate="visible"
+          variants={fadeInUp}
+          className="mb-5 inline-flex h-[50px] w-[160px] items-center justify-center border-4 border-[#EF3340] bg-[#0d1c46]/50 text-xl font-bold text-white"
+        >
           Case Study
-        </p>
+        </motion.p>
 
-        <div className="mb-4 flex flex-col gap-5 lg:flex-row lg:items-center lg:gap-6">
+        <motion.div
+          custom={2}
+          initial="hidden"
+          animate="visible"
+          variants={fadeInUp}
+          className="mb-4 flex flex-col gap-5 lg:flex-row lg:items-center lg:gap-6"
+        >
           <Image
             src={carnivalLogo}
             alt="Carnival"
@@ -30,15 +58,24 @@ export default function CarnivalLandingSection() {
             className="h-auto mt-8 w-full max-w-[400px]"
             priority
           />
-        </div>
+        </motion.div>
 
-        <div className="mt-6 h-[4px] w-full max-w-[48rem] bg-[#EF3340] sm:max-w-[28rem] lg:max-w-[56rem]" />
+        <motion.div
+          initial={{ scaleX: 0 }}
+          animate={{ scaleX: 1 }}
+          transition={{ duration: 1, delay: 0.15, ease: "circOut" }}
+          className="mt-6 h-[4px] w-full max-w-[48rem] bg-[#EF3340] origin-left sm:max-w-[28rem] lg:max-w-[56rem]"
+        />
 
-        <h2
+        <motion.h2
+          custom={1}
+          initial="hidden"
+          animate="visible"
+          variants={fadeInUp}
           className={`${gentonaBold.className} mt-30 max-w-4xl text-3xl font-bold leading-tight sm:text-4xl lg:text-5xl`}
         >
           The Agency Helps Carnival Navigate the Sentiments of Travelers Post-2021
-        </h2>
+        </motion.h2>
       </div>
     </section>
   );

--- a/frontend/src/app/portfolio/caseStudies/Carnival/components/CarnivalMeaningSection.tsx
+++ b/frontend/src/app/portfolio/caseStudies/Carnival/components/CarnivalMeaningSection.tsx
@@ -9,13 +9,13 @@ export default function CarnivalMeaningSection() {
     <section className="relative overflow-hidden py-14 md:py-22">
       <div className="relative z-10 px-6 md:px-12 lg:pl-20 lg:pr-0">
         <div className="mx-auto max-w-6xl">
-          <h2 className="text-center text-5xl py-6 font-extrabold uppercase leading-none text-white md:text-7xl">
+          <h2 className="py-10 text-center text-5xl font-extrabold uppercase leading-none text-white md:py-14 md:text-7xl">
             So, What Does This Mean?
           </h2>
 
           <div className="mt-12 grid items-start gap-10 lg:grid-cols-[minmax(0,1fr)_34rem] xl:grid-cols-[minmax(0,1fr)_44rem]">
-            <div className="max-w-2xl">
-              <h3 className="text-2xl font-extrabold uppercase text-white md:text-4xl">
+            <div className="max-w-4xl lg:-ml-6">
+              <h3 className="text-2xl font-extrabold uppercase text-white md:text-4xl lg:whitespace-nowrap">
                 The Answer Is... Relationships.
               </h3>
 

--- a/frontend/src/app/portfolio/caseStudies/Carnival/components/CarnivalMeaningSection.tsx
+++ b/frontend/src/app/portfolio/caseStudies/Carnival/components/CarnivalMeaningSection.tsx
@@ -1,20 +1,48 @@
+"use client";
+
 import Image from "next/image";
-import dottedRedCircle from "../assets/dotted-redCircle.svg";
+import { motion } from "framer-motion";
 import meaningPhoto from "../assets/MeaningPhoto.png";
 import tweets from "../assets/Tweets.png";
 
-
 export default function CarnivalMeaningSection() {
+  const fadeInUp = {
+    hidden: { opacity: 0, y: 30 },
+    visible: (custom: number) => ({
+      opacity: 1,
+      y: 0,
+      transition: {
+        duration: 0.8,
+        delay: custom * 0.15,
+        ease: [0.21, 0.47, 0.32, 0.98] as const,
+      },
+    }),
+  };
+
   return (
     <section className="relative overflow-hidden py-14 md:py-22">
       <div className="relative z-10 px-6 md:px-12 lg:pl-20 lg:pr-0">
         <div className="mx-auto max-w-6xl">
-          <h2 className="py-10 text-center text-5xl font-extrabold uppercase leading-none text-white md:py-14 md:text-7xl">
+          <motion.h2
+            custom={1}
+            initial="hidden"
+            whileInView="visible"
+            viewport={{ once: true }}
+            variants={fadeInUp}
+            className="py-10 text-center text-5xl font-extrabold uppercase leading-none text-white md:py-14 md:text-7xl"
+          >
             So, What Does This Mean?
-          </h2>
+          </motion.h2>
 
           <div className="mt-12 grid items-start gap-10 lg:grid-cols-[minmax(0,1fr)_34rem] xl:grid-cols-[minmax(0,1fr)_44rem]">
-            <div className="max-w-4xl lg:-ml-6">
+            <motion.div
+              custom={2}
+              initial="hidden"
+              whileInView="visible"
+              viewport={{ once: true }}
+              variants={fadeInUp}
+              className="max-w-4xl lg:-ml-6"
+            >
               <h3 className="text-2xl font-extrabold uppercase text-white md:text-4xl lg:whitespace-nowrap">
                 The Answer Is... Relationships.
               </h3>
@@ -31,9 +59,16 @@ export default function CarnivalMeaningSection() {
                   spend memorable, quality time with.
                 </p>
               </div>
-            </div>
+            </motion.div>
 
-            <div className="relative mx-auto w-full max-w-[38rem] lg:ml-auto lg:mr-0 lg:max-w-[44rem]">
+            <motion.div
+              custom={3}
+              initial="hidden"
+              whileInView="visible"
+              viewport={{ once: true }}
+              variants={fadeInUp}
+              className="relative mx-auto w-full max-w-[38rem] lg:ml-auto lg:mr-0 lg:max-w-[44rem]"
+            >
               <Image
                 src={tweets}
                 alt="Traveler conversation tweets"
@@ -41,16 +76,30 @@ export default function CarnivalMeaningSection() {
                 height={720}
                 className="h-auto w-full object-contain"
               />
-            </div>
+            </motion.div>
           </div>
 
           <div className="mt-16">
-            <h3 className="text-center text-2xl font-extrabold uppercase text-white md:text-4xl">
+            <motion.h3
+              custom={1}
+              initial="hidden"
+              whileInView="visible"
+              viewport={{ once: true }}
+              variants={fadeInUp}
+              className="text-center text-2xl font-extrabold uppercase text-white md:text-4xl"
+            >
               People Are Excited To Travel... But Why Are They Excited?
-            </h3>
+            </motion.h3>
 
             <div className="relative mt-8 grid items-start gap-10 lg:grid-cols-[28rem_minmax(0,1fr)] xl:grid-cols-[34rem_minmax(0,1fr)]">
-              <div className="relative mx-auto w-full max-w-[28rem] lg:-ml-24 lg:mr-0 lg:max-w-[34rem]">
+              <motion.div
+                custom={2}
+                initial="hidden"
+                whileInView="visible"
+                viewport={{ once: true }}
+                variants={fadeInUp}
+                className="relative mx-auto w-full max-w-[28rem] lg:-ml-24 lg:mr-0 lg:max-w-[34rem]"
+              >
                 <div className="relative z-20 overflow-hidden">
                   <Image
                     src={meaningPhoto}
@@ -60,9 +109,16 @@ export default function CarnivalMeaningSection() {
                     className="h-auto w-full object-cover"
                   />
                 </div>
-              </div>
+              </motion.div>
 
-              <div className="relative max-w-3xl text-white">
+              <motion.div
+                custom={3}
+                initial="hidden"
+                whileInView="visible"
+                viewport={{ once: true }}
+                variants={fadeInUp}
+                className="relative max-w-3xl text-white"
+              >
                 <p className="text-lg font-extrabold md:text-2xl">
                   The top two results pulled from the Quid map:
                 </p>
@@ -94,9 +150,7 @@ export default function CarnivalMeaningSection() {
                     </p>
                   </div>
                 </div>
-
-                
-              </div>
+              </motion.div>
             </div>
           </div>
         </div>

--- a/frontend/src/app/portfolio/caseStudies/Carnival/components/CarnivalOpportunitySection.tsx
+++ b/frontend/src/app/portfolio/caseStudies/Carnival/components/CarnivalOpportunitySection.tsx
@@ -1,15 +1,38 @@
+"use client";
+
 import Image from "next/image";
 import cautiousTraveler from "../assets/CautiousTraveler.png";
 import dottedRedCircle from "../assets/dotted-redCircle.svg";
 import opportunityPhoto from "../assets/Opportunity-Photo.png";
 import prospectiveTraveler from "../assets/ProspectiveTraveler.png";
+import { motion } from "framer-motion";
 
 export default function CarnivalOpportunitySection() {
+  const fadeInUp = {
+    hidden: { opacity: 0, y: 30 },
+    visible: (custom: number) => ({
+      opacity: 1,
+      y: 0,
+      transition: {
+        duration: 0.8,
+        delay: custom * 0.15,
+        ease: [0.21, 0.47, 0.32, 0.98] as const,
+      },
+    }),
+  };
+
   return (
     <section className="relative  py-0 md:py-14">
       <div className="relative z-10 px-6 md:px-12 lg:px-20">
         {/* Title + text + image all in one row so image starts at the top */}
-        <div className="flex flex-col gap-8 lg:flex-row lg:items-start lg:gap-12">
+        <motion.div
+          custom={1}
+          initial="hidden"
+          whileInView="visible"
+          viewport={{ once: true }}
+          variants={fadeInUp}
+          className="flex flex-col gap-8 lg:flex-row lg:items-start lg:gap-12"
+        >
           <div className="flex-1">
             <div className="py-6 -mt-30">
               <h2 className="text-7xl font-extrabold md:text-8xl">THE</h2>
@@ -57,20 +80,34 @@ export default function CarnivalOpportunitySection() {
               className="h-auto w-full object-cover"
             />
           </div>
-        </div>
+        </motion.div>
 
         {/* Stat + traveler cards */}
         <div className="">
-          <p className="mb-8 text-base md:text-3xl max-w-[68rem]">
+          <motion.p
+            custom={2}
+            initial="hidden"
+            whileInView="visible"
+            viewport={{ once: true }}
+            variants={fadeInUp}
+            className="mb-8 text-base md:text-3xl max-w-[68rem]"
+          >
             After refining our search, we pulled{" "}
             <span className="font-extrabold">21.3 MILLION</span> results to find
             the following: There are <strong>two</strong> types of people that
             want to travel in 2022.
-          </p>
+          </motion.p>
 
           <div className="mx-auto grid max-w-[72rem] grid-cols-1 gap-15 md:grid-cols-2 md:gap-20">
             {/* Cautious Traveler */}
-            <div className="relative overflow-visible">
+            <motion.div
+              custom={3}
+              initial="hidden"
+              whileInView="visible"
+              viewport={{ once: true }}
+              variants={fadeInUp}
+              className="relative overflow-visible"
+            >
               <Image
                 src={cautiousTraveler}
                 alt="The cautious traveler"
@@ -98,10 +135,17 @@ export default function CarnivalOpportunitySection() {
                   cancellations, etc.
                 </p>
               </div>
-            </div>
+            </motion.div>
 
             {/* Prospective Traveler */}
-            <div className="relative overflow-hidden">
+            <motion.div
+              custom={4}
+              initial="hidden"
+              whileInView="visible"
+              viewport={{ once: true }}
+              variants={fadeInUp}
+              className="relative overflow-hidden"
+            >
               <Image
                 src={prospectiveTraveler}
                 alt="The prospective traveler"
@@ -119,7 +163,7 @@ export default function CarnivalOpportunitySection() {
                   little time.
                 </p>
               </div>
-            </div>
+            </motion.div>
           </div>
         </div>
       </div>

--- a/frontend/src/app/portfolio/caseStudies/Carnival/components/CarnivalSolutionSection.tsx
+++ b/frontend/src/app/portfolio/caseStudies/Carnival/components/CarnivalSolutionSection.tsx
@@ -1,46 +1,103 @@
+"use client";
+
 import Image from "next/image";
+import { motion } from "framer-motion";
 import solutionPhoto from "../assets/SolutionPhoto.png";
 
 export default function CarnivalSolutionSection() {
+  const fadeInUp = {
+    hidden: { opacity: 0, y: 30 },
+    visible: (custom: number) => ({
+      opacity: 1,
+      y: 0,
+      transition: {
+        duration: 0.8,
+        delay: custom * 0.15,
+        ease: [0.21, 0.47, 0.32, 0.98] as const,
+      },
+    }),
+  };
+
   return (
     <section className="relative overflow-hidden py-12 md:py-20">
       <div className="relative z-10 px-6 md:px-12 lg:pl-20 lg:pr-0">
         <div className="grid items-start gap-12 lg:grid-cols-[minmax(0,1fr)_32rem] lg:gap-12 xl:grid-cols-[minmax(0,1fr)_32rem]">
           <div className="max-w-3xl">
-            <div className="-ml-8 block max-w-xl bg-white px-8 py-1 md:-ml-14 md:px-14 md:py-2 lg:-ml-22 lg:px-20 lg:py-4">
+            <motion.div
+              custom={1}
+              initial="hidden"
+              whileInView="visible"
+              viewport={{ once: true }}
+              variants={fadeInUp}
+              className="-ml-8 block max-w-xl bg-white px-8 py-1 md:-ml-14 md:px-14 md:py-2 lg:-ml-22 lg:px-20 lg:py-4"
+            >
               <h2 className="text-6xl font-extrabold leading-none text-[#004E8E] md:text-7xl lg:text-8xl">
                 THE
               </h2>
               <h2 className="text-6xl font-extrabold leading-none text-[#EF3340] md:text-7xl lg:text-8xl">
                 SOLUTION
               </h2>
-            </div>
+            </motion.div>
 
-            <div className="-ml-6 mt-6 h-[4px] w-full max-w-[36rem] bg-[#EF3340] md:-ml-12 lg:-ml-20" />
+            <motion.div
+              initial={{ scaleX: 0 }}
+              whileInView={{ scaleX: 1 }}
+              viewport={{ once: true }}
+              transition={{ duration: 1, delay: 0.2, ease: "circOut" }}
+              className="-ml-6 mt-6 h-[4px] w-full max-w-[36rem] bg-[#EF3340] origin-left md:-ml-12 lg:-ml-20"
+            />
 
             <div className="mt-8 space-y-8 text-white">
-              <p className="max-w-3xl text-base leading-tight md:text-3xl">
+              <motion.p
+                custom={2}
+                initial="hidden"
+                whileInView="visible"
+                viewport={{ once: true }}
+                variants={fadeInUp}
+                className="max-w-3xl text-base leading-tight md:text-3xl"
+              >
                 Analyzing global conversations from 21.3 million results led us
                 to two types of travelers:{" "}
                 <strong>the cautious traveler</strong> and{" "}
                 <strong>the prospective traveler.</strong>
-              </p>
+              </motion.p>
 
-              <p className="max-w-4xl text-base leading-tight md:text-3xl">
+              <motion.p
+                custom={3}
+                initial="hidden"
+                whileInView="visible"
+                viewport={{ once: true }}
+                variants={fadeInUp}
+                className="max-w-4xl text-base leading-tight md:text-3xl"
+              >
                 We provided Carnival with a more in-depth understanding of
                 post-quarantine travel sentiments by defining priorities for
                 travelers.
-              </p>
+              </motion.p>
 
-              <p className="max-w-4xl text-base leading-tight md:text-3xl">
+              <motion.p
+                custom={4}
+                initial="hidden"
+                whileInView="visible"
+                viewport={{ once: true }}
+                variants={fadeInUp}
+                className="max-w-4xl text-base leading-tight md:text-3xl"
+              >
                 Carnival used our traveler profiles to create a compelling
                 Funderstruck campaign that appeals to both cautious and
                 prospective travelers.
-              </p>
+              </motion.p>
             </div>
           </div>
 
-          <div className="relative mx-auto w-full max-w-[36rem] lg:ml-auto lg:mr-0 lg:-mt-12 lg:w-[36rem] lg:max-w-[36rem]">
+          <motion.div
+            custom={2}
+            initial="hidden"
+            whileInView="visible"
+            viewport={{ once: true }}
+            variants={fadeInUp}
+            className="relative mx-auto w-full max-w-[36rem] lg:ml-auto lg:mr-0 lg:-mt-12 lg:w-[36rem] lg:max-w-[36rem]"
+          >
             <div className="relative">
               <Image
                 src={solutionPhoto}
@@ -52,10 +109,7 @@ export default function CarnivalSolutionSection() {
                 className="h-auto w-full object-contain"
               />
             </div>
-
-
-            
-          </div>
+          </motion.div>
         </div>
       </div>
     </section>

--- a/frontend/src/app/portfolio/caseStudies/Carnival/components/CarnivalStatsSection.tsx
+++ b/frontend/src/app/portfolio/caseStudies/Carnival/components/CarnivalStatsSection.tsx
@@ -1,14 +1,45 @@
+"use client";
+
+import { motion } from "framer-motion";
+
 export default function CarnivalStatsSection() {
+  const fadeInUp = {
+    hidden: { opacity: 0, y: 30 },
+    visible: (custom: number) => ({
+      opacity: 1,
+      y: 0,
+      transition: {
+        duration: 0.8,
+        delay: custom * 0.15,
+        ease: [0.21, 0.47, 0.32, 0.98] as const,
+      },
+    }),
+  };
+
   return (
     <section className="relative py-8 md:py-12">
       <div className="relative z-10 px-6 md:px-12 lg:px-20">
         <div className="mx-auto max-w-6xl px-6 py-5 text-center text-white md:px-10 md:py-7">
-          <p className="text-4xl font-extrabold uppercase leading-none md:text-6xl">
+          <motion.p
+            custom={1}
+            initial="hidden"
+            whileInView="visible"
+            viewport={{ once: true }}
+            variants={fadeInUp}
+            className="text-4xl font-extrabold uppercase leading-none md:text-6xl"
+          >
             8 Published Trade Articles
-          </p>
-          <p className="mt-2 text-4xl font-extrabold uppercase leading-none md:text-6xl">
+          </motion.p>
+          <motion.p
+            custom={2}
+            initial="hidden"
+            whileInView="visible"
+            viewport={{ once: true }}
+            variants={fadeInUp}
+            className="mt-2 text-4xl font-extrabold uppercase leading-none md:text-6xl"
+          >
             230,000+ Impressions
-          </p>
+          </motion.p>
         </div>
       </div>
     </section>

--- a/frontend/src/app/portfolio/caseStudies/Carnival/page.tsx
+++ b/frontend/src/app/portfolio/caseStudies/Carnival/page.tsx
@@ -33,7 +33,7 @@ export default function CarnivalPage() {
         <div className="relative z-10 mt-8 md:mt-18">
           <CarnivalMeaningSection />
         </div>
-        <div className="relative z-10 mt-[1rem] md:mt-[3rem]">
+        <div className="relative z-10 ">
           <CarnivalStatsSection />
         </div>
         <div className="relative z-10 mt-4 md:mt-8">


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
- Had to fix sizing issue with headline section photos, some article titles were cut off. 
- Made width of "Meaning Section" text bigger to better match the figma
- Referenced the Amazon Alexa page, and used the same "fade up on scroll" animations for my components

## Related Issue
<!--- Please include the issue ticket number and link -->
Ensure all case study pages have framer animations #52 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- Made changes to better align with the figma, articles were cut off. 
- Animations requested for all case studies


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested locally on my device using npm run dev

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.

## Screenshots (if appropriate):
<img width="1470" height="956" alt="Screenshot 2026-04-14 at 5 33 59 AM" src="https://github.com/user-attachments/assets/46b9bc57-3ad4-4927-9fc2-7625de2a902f" />
<img width="1470" height="956" alt="Screenshot 2026-04-14 at 5 34 15 AM" src="https://github.com/user-attachments/assets/12818b17-22f7-4181-a54e-5cb88a5ca07c" />
